### PR TITLE
認可処理

### DIFF
--- a/src/main/java/oit/is/team08/lec03/security/Sample3AuthConfiguration.java
+++ b/src/main/java/oit/is/team08/lec03/security/Sample3AuthConfiguration.java
@@ -14,7 +14,25 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableWebSecurity
 public class Sample3AuthConfiguration {
 
-
+  /**
+   * 認可処理に関する設定（認証されたユーザがどこにアクセスできるか）
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.formLogin(login -> login
+        .permitAll())
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/sample3/**")).authenticated() // /sample3/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()); // それ以外は全員アクセス可能
+    return http.build();
+  }
 
   /**
    * 認証処理に関する設定（誰がどのようなロールでログインできるか）


### PR DESCRIPTION
認可処理を実装
・SpringSecurityのフォームを利用する
・/sample3 で始まるURLへのアクセス時にのみ認証を必要とする (例：http://localhost:8080/sample3/hoge)
・ログアウト時にはトップページ (http://localhost:8080/)に戻る