### PR TITLE
ユーザ名とロール名を表示出来る様にしました

### DIFF
--- a/src/main/resources/templates/sample33.html
+++ b/src/main/resources/templates/sample33.html
@@ -8,8 +8,13 @@
 
 <body>
   <div><a href="/logout">ログアウト</a></div>
-
-
+  <h2>ユーザ名とロール名の表示(Sample3-4)</h2>
+  java上でPrinciplesから値を取得する方法ではなく，thymeleaf-extras-springsecurityプラグインを利用してhtmlから直接ユーザ名やPrinciples（ロール情報）を取得する方法を試す．
+  <!--sec:authenticationで認証情報にアクセスできる．nameはユーザ名を表す-->
+  <h3>ユーザ名：<div sec:authentication="name"></div>
+  </h3>
+  <h3>ロール名：<div sec:authentication="principal.authorities"></div>
+  </h3>
 
 
 </body>


### PR DESCRIPTION
ThymeleafとSpring Securityを連携するライブラリ(thymeleaf-extras-springsecurity)の機能を利用し，html上でユーザ名とロール名を表示する処理を実装しました